### PR TITLE
Fix build error on kernel 6.6.113

### DIFF
--- a/nft-fullcone/src/nft_ext_fullcone.c
+++ b/nft-fullcone/src/nft_ext_fullcone.c
@@ -121,7 +121,7 @@ static int exp_event_cb(unsigned int events, const struct nf_exp_event *item)
 }
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 113)
 // include/net/netfilter/nf_tables.h validate function signature changed
 static int nft_fullcone_validate(const struct nft_ctx *ctx, const struct nft_expr *expr)
 #else


### PR DESCRIPTION
Change the version check condition for nft_fullcone_validate function signature  from KERNEL_VERSION(6, 12, 0) to KERNEL_VERSION(6, 6, 113) to precisely match  the kernel version where this API change was introduced.

In Linux 6.6.113 and later, the nft_fullcone_validate function signature changed from: `int (*)(const struct nft_ctx *, const struct nft_expr *, const struct nft_data **)` to:
`int (*)(const struct nft_ctx *, const struct nft_expr *)`

This fix resolves function signature mismatch errors when compiling with  Linux 6.6.113 and later kernels while maintaining compatibility with earlier versions.