### PR TITLE
fix(patch): refresh conntrack multi-registrant patch for linux 6.6.133

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,293 @@
+name: Test luci-app-turboacc
+on:
+  workflow_dispatch:
+  pull_request:
+            branches:
+              - luci
+              - package
+            paths:
+              - '!README.md'
+              - '!.github/**'
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        tag_branche: [master,openwrt-25.12,openwrt-24.10,openwrt-23.05,openwrt-22.03]
+        compile: [FLOW_OFFLOAD,SHORTCUT_FE,SHORTCUT_FE_CM,SHORTCUT_FE_DRV]
+    steps:
+          - name: 将存储库签出到运行器
+            uses: actions/checkout@v4
+            with:
+                ref: 'luci'
+                path: luci-app-turboacc
+
+          - name: 将存储库签出到运行器
+            uses: actions/checkout@v4
+            with:
+                path: turboacc
+
+          - name: 设置变量
+            run: |
+                export TURBOACC_PATH="$(pwd)/turboacc"
+                export LUCI_APP_TURBOACC_PATH="$(pwd)/luci-app-turboacc"
+                echo "TURBOACC_PATH=$TURBOACC_PATH" >> $GITHUB_ENV
+                echo "LUCI_APP_TURBOACC_PATH=$LUCI_APP_TURBOACC_PATH" >> $GITHUB_ENV
+
+          - name: 检测
+            run: ls -la $(find $GITHUB_WORKSPACE -type d)
+
+          - name: 安装编译依赖
+            run: |
+              sudo -E apt update
+              sudo -E apt-mark hold grub-efi-amd64-signed
+              sudo -E apt -y full-upgrade
+              sudo apt install -y build-essential clang flex bison g++ gawk gcc-multilib g++-multilib \
+              gettext git libncurses-dev libssl-dev python3-distutils rsync unzip zlib1g-dev file wget
+              sudo -E systemctl daemon-reload 
+              sudo -E apt -y autoremove --purge
+              sudo -E apt clean
+              sudo timedatectl set-timezone "Asia/Shanghai"
+    
+          - name: 克隆源代码
+            run: |
+                git clone https://github.com/openwrt/openwrt.git
+                cd openwrt
+                export OPENWRT_ROOT_PATH="$(pwd)"
+                echo "OPENWRT_ROOT_PATH=$OPENWRT_ROOT_PATH" >> $GITHUB_ENV
+    
+          - name: 切换标签/分支
+            run: |
+              echo "${{ matrix.tag_branche }}"
+              cd $OPENWRT_ROOT_PATH
+              git checkout "${{ matrix.tag_branche }}"
+    
+          - name: 修复问题
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            run: |
+              sed -i 's/^  DEPENDS:= +kmod-crypto-manager +kmod-crypto-pcbc +kmod-crypto-fcrypt$/  DEPENDS:= +kmod-crypto-manager +kmod-crypto-pcbc +kmod-crypto-fcrypt +kmod-udptunnel4 +kmod-udptunnel6/' package/kernel/linux/modules/netsupport.mk #https://github.com/openwrt/openwrt/commit/ecc53240945c95bc77663b79ccae6e2bd046c9c8
+              sed -i 's/^	dnsmasq \\$/	dnsmasq-full \\/g' ./include/target.mk
+              sed -i 's/^	b43-fwsquash.py "$(CONFIG_B43_FW_SQUASH_PHYTYPES)" "$(CONFIG_B43_FW_SQUASH_COREREVS)"/	$(TOPDIR)\/tools\/b43-tools\/files\/b43-fwsquash.py "$(CONFIG_B43_FW_SQUASH_PHYTYPES)" "$(CONFIG_B43_FW_SQUASH_COREREVS)"/' ./package/kernel/mac80211/broadcom.mk
+    
+          - name: 更新 feeds 
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            run: |
+              ./scripts/feeds update -a
+              ./scripts/feeds install -a
+    
+          - name: 生成配置文件
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            run: |
+              if [ "${{ matrix.compile }}" = "SHORTCUT_FE_DRV" ]; then
+                echo "CONFIG_TARGET_ipq807x=y" >> $OPENWRT_ROOT_PATH/.config
+                echo "CONFIG_TARGET_ipq807x_generic=y" >> $OPENWRT_ROOT_PATH/.config
+                echo "CONFIG_TARGET_ipq807x_generic_DEVICE_redmi_ax6=y" >> $OPENWRT_ROOT_PATH/.config
+              else
+                echo "CONFIG_TARGET_x86=y" >> $OPENWRT_ROOT_PATH/.config
+                echo "CONFIG_TARGET_x86_64=y" >> $OPENWRT_ROOT_PATH/.config
+                echo "CONFIG_TARGET_x86_64_DEVICE_generic=y" >> $OPENWRT_ROOT_PATH/.config
+              fi
+              make defconfig
+              
+          - name: 添加turboacc
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            run: |
+              if [ "${{ matrix.compile }}" = "FLOW_OFFLOAD" ]; then
+                curl -sSL https://raw.githubusercontent.com/chenmozhijin/turboacc/luci/add_turboacc.sh -o add_turboacc.sh && bash add_turboacc.sh --no-sfe --local-pkg $TURBOACC_PATH
+              else
+                curl -sSL https://raw.githubusercontent.com/chenmozhijin/turboacc/luci/add_turboacc.sh -o add_turboacc.sh && bash add_turboacc.sh --local-pkg $TURBOACC_PATH
+              fi
+              kernel_version="$(sed -n '/CONFIG_LINUX_/p' $OPENWRT_ROOT_PATH/.config | sed -e 's/CONFIG_LINUX_//' -e 's/=y//' -e 's/_/./g')"
+              #log
+              echo "libnftnl-file"
+              ls $OPENWRT_ROOT_PATH/package/libs/libnftnl
+              echo "firewall4-file"
+              ls $OPENWRT_ROOT_PATH/package/network/config/firewall4
+              echo "nftables-file"
+              ls $OPENWRT_ROOT_PATH/package/network/utils/nftables
+              echo "firewall4-patches"
+              ls $OPENWRT_ROOT_PATH/package/network/config/firewall4/patches/
+              echo "libnftnl-patches"
+              ls $OPENWRT_ROOT_PATH/package/libs/libnftnl/patches/
+              echo "nftables-patches"
+              ls $OPENWRT_ROOT_PATH/package/network/utils/nftables/patches/
+              echo "hack-$kernel_version" 
+              ls $OPENWRT_ROOT_PATH/target/linux/generic/hack-$kernel_version
+              echo "pending-$kernel_version" 
+              ls $OPENWRT_ROOT_PATH/target/linux/generic/pending-$kernel_version
+    
+          - name: 加载配置并生成配置文件
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            run: |
+              echo "compile = "${{ matrix.compile }}
+              rm -rf .config .config.old tmp
+              ls -la
+              if [ "${{ matrix.compile }}" = "SHORTCUT_FE_DRV" ]; then
+                echo "CONFIG_TARGET_ipq807x=y" >> $OPENWRT_ROOT_PATH/.config
+                echo "CONFIG_TARGET_ipq807x_generic=y" >> $OPENWRT_ROOT_PATH/.config
+                echo "CONFIG_TARGET_ipq807x_generic_DEVICE_redmi_ax6=y" >> $OPENWRT_ROOT_PATH/.config
+              else
+                echo "CONFIG_TARGET_x86=y" >> $OPENWRT_ROOT_PATH/.config
+                echo "CONFIG_TARGET_x86_64=y" >> $OPENWRT_ROOT_PATH/.config
+                echo "CONFIG_TARGET_x86_64_DEVICE_generic=y" >> $OPENWRT_ROOT_PATH/.config
+              fi
+              echo 'CONFIG_PACKAGE_luci-app-turboacc=y' >> .config
+              echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_BBR_CCA=y' >> .config
+              echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_NFT_FULLCONE=y' >> .config
+              if [ "${{ matrix.compile }}" = "FLOW_OFFLOAD" ]; then
+                echo "FLOW_OFFLOAD"
+                echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_OFFLOADING=y' >> .config
+                echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_SHORTCUT_FE=n' >> .config
+                echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_SHORTCUT_FE_CM=n' >> .config
+              elif [ "${{ matrix.compile }}" = "SHORTCUT_FE" ]; then
+                echo "SHORTCUT_FE"
+                echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_OFFLOADING=n' >> .config
+                echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_SHORTCUT_FE=y' >> .config
+                echo 'CONFIG_PACKAGE_kmod-shortcut-fe-cm=n' >> .config
+              elif [ "${{ matrix.compile }}" = "SHORTCUT_FE_CM" ]; then
+                echo "SHORTCUT_FE_CM"
+                echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_OFFLOADING=n' >> .config
+                echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_SHORTCUT_FE_CM=y' >> .config
+              elif [ "${{ matrix.compile }}" = "SHORTCUT_FE_DRV" ]; then
+                echo "SHORTCUT_FE_DRV"
+                echo 'CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_OFFLOADING=n' >> .config
+                echo "CONFIG_PACKAGE_luci-app-turboacc_INCLUDE_SHORTCUT_FE_DRV=y" >> $OPENWRT_ROOT_PATH/.config
+              else
+                echo "compile = "${{ matrix.compile }}
+                exit 1
+              fi
+              echo ".config"
+              cat .config
+              make defconfig
+              echo "diffconfig"
+              ./scripts/diffconfig.sh
+    
+          - name: 下载 dl 库
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            run: |
+              make download -j16
+              find dl -size -1024c -exec ls -l {} \;
+              find dl -size -1024c -exec rm -f {} \;
+              make download -j16 || make download -j1 V=s
+    
+    #      - name: 下载工具链库
+    #        run: |
+    #          cd $OPENWRT_ROOT_PATH
+    #          mkdir -p staging_dir
+    #          CONFIG_TARGET_BOARD=$(sed -n 's/CONFIG_TARGET_BOARD="\(.*\)"/\1/p' .config) #x86
+    #          CONFIG_TARGET_SUBTARGET=$(sed -n 's/CONFIG_TARGET_SUBTARGET="\(.*\)"/\1/p' .config) #64
+    #          if [ "${{ matrix.tag_branche }}" = "master" ]; then
+    #            RELEASE=snapshots
+    #          elif [ "${{ matrix.tag_branche }}" = "openwrt-23.05" ] || [ "${{ matrix.tag_branche }}" = "v23.05.0" ]; then
+    #            RELEASE=releases/v23.05.0
+    #          elif [ "${{ matrix.tag_branche }}" = "openwrt-22.03" ] || [ "${{ matrix.tag_branche }}" = "v22.03.5" ]; then
+    #            RELEASE=releases/22.03.5
+    #          fi
+    #          FILE_NAME=$(curl -s -L --retry 3 --connect-timeout 20 https://downloads.openwrt.org/snapshots/targets/$CONFIG_TARGET_BOARD/$CONFIG_TARGET_SUBTARGET/ | grep -m 1 -o "openwrt-toolchain-${CONFIG_TARGET_BOARD}-${CONFIG_TARGET_SUBTARGET}_gcc[^\"]*\.Linux-${CONFIG_TARGET_BOARD}_${CONFIG_TARGET_SUBTARGET}\.tar\.xz" | sed 's/^.*<a href="//' | sort -u)
+    #          curl -L --retry 3 --connect-timeout 20 https://downloads.openwrt.org/$RELEASE/targets/$CONFIG_TARGET_BOARD/$CONFIG_TARGET_SUBTARGET/$FILE_NAME -o staging_dir/toolchain.tar.xz
+    #          cd staging_dir
+    #          tar xf toolchain.tar.xz
+    #          cp -r ./openwrt-toolchain-*/toolchain-* .
+    #          rm -rf ./openwrt-toolchain-*
+
+    
+          - name: 获取信息
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            id: get-info
+            run: |
+              toolchain_commit=$(git log --pretty=tformat:"%h" -n1 tools toolchain)
+              target=$(sed -n '/^CONFIG_TARGET_BOARD/p' ${{ env.OPENWRT_ROOT_PATH }}/.config | sed -e 's/CONFIG_TARGET_BOARD\=\"//' -e 's/\"//')
+              subtarget=$(sed -n '/^CONFIG_TARGET_SUBTARGET/p' ${{ env.OPENWRT_ROOT_PATH }}/.config | sed -e 's/CONFIG_TARGET_SUBTARGET\=\"//' -e 's/\"//')
+              echo "target=$target" >> "$GITHUB_OUTPUT"
+              echo "subtarget=$subtarget" >> "$GITHUB_OUTPUT"
+              echo "toolchain_commit=$toolchain_commit" >> "$GITHUB_OUTPUT"
+
+          - name: 缓存toolchain
+            uses: actions/cache@v4
+            id: cache-toolchain
+            with:
+              path: |
+                ${{ env.OPENWRT_ROOT_PATH }}/staging_dir/host*
+                ${{ env.OPENWRT_ROOT_PATH }}/staging_dir/tool*
+              key: toolchain-${{ steps.get-info.outputs.toolchain_commit }}-${{ steps.get-info.outputs.target }}-${{ steps.get-info.outputs.subtarget }}
+
+          - name: 构建工具
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
+            run: |
+              make tools/install -j $(($(nproc)+1)) || make tools/install -j1 V=s
+              echo "======================="
+              echo "空间使用情况:"
+              echo "======================="
+              df --total  -Th
+              echo "======================="
+      
+          - name: 构建工具链
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
+            run: |
+              make toolchain/install -j $(($(nproc)+1)) || make toolchain/install -j1 V=s
+              echo "======================="
+              echo "空间使用情况:"
+              echo "======================="
+              df --total  -Th
+              echo "======================="
+    
+          - name: 构建内核
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            run: |
+              make target/compile -j $(($(nproc)+1)) || make target/compile -j$(nproc) V=s || make target/compile -j1 V=s
+              echo "======================="
+              echo "空间使用情况:"
+              echo "======================="
+              df --total  -Th
+              echo "======================="
+    
+          - name: 编译并生成安装包
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            run: |
+              make package/compile -j $(($(nproc)+1)) || make package/compile -j1 V=s
+              make package/install -j $(($(nproc)+1)) || make package/install -j1 V=s
+              echo "======================="
+              echo "空间使用情况:"
+              echo "======================="
+              df --total  -Th
+              echo "======================="
+              du -h --max-depth=1 ./ --exclude=build_dir --exclude=bin
+              du -h --max-depth=1 ./build_dir
+              du -h --max-depth=1 ./bin
+    
+          - name: 准备 artifact
+            working-directory: ${{ env.OPENWRT_ROOT_PATH }}
+            run: |
+              mkdir -p ./artifact
+              ls -la $(find ./bin/packages/ -type d)
+              cp -rf $(find ./bin/packages/ -type f \( -name "*.ipk" -o -name "*.apk" \)) ./artifact
+              cp -rf $(find ./bin/packages/ -type f \( -name "*.ipk" -o -name "*.apk" \)) ./artifact
+    
+          - name: 上传build artifacts
+            uses: actions/upload-artifact@v4
+            with:
+              name: packages-${{ matrix.tag_branche }}-${{ matrix.compile }}
+              path: ${{ env.OPENWRT_ROOT_PATH }}/artifact/**
+    
+          - name: 收集日志
+            if: success() || failure()
+            run: |
+              mkdir -p logs
+              cd logs
+              export LOG_PATH="$(pwd)"
+              echo "LOG_PATH=$LOG_PATH" >> $GITHUB_ENV
+              cp -r $OPENWRT_ROOT_PATH/logs $LOG_PATH/openwrt-logs || echo "没有openwrt/logs"
+              cp $OPENWRT_ROOT_PATH/.config $LOG_PATH/openwrt.config || echo "没有openwrt/.config"
+              ls -la $(find $OPENWRT_ROOT_PATH/package/ -type d)  >> $LOG_PATH/package_files.list
+              ls -la $(find $OPENWRT_ROOT_PATH/linux/generic/ -type d)  >> $LOG_PATH/kp_files.list
+    
+          - name: 上传日志
+            if: success() || failure()
+            uses: actions/upload-artifact@v4
+            with:
+              name: logs-${{ matrix.tag_branche }}-${{ matrix.compile }}
+              path: "${{ env.LOG_PATH }}"

--- a/hack-6.12/952-add-net-conntrack-events-support-multiple-registrant.patch
+++ b/hack-6.12/952-add-net-conntrack-events-support-multiple-registrant.patch
@@ -329,7 +329,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	struct nf_conn *ct = item->ct;
  	struct sk_buff *skb;
  	unsigned int type;
-@@ -3094,6 +3101,7 @@ nla_put_failure:
+@@ -3097,6 +3097,7 @@
  }
  
  #ifdef CONFIG_NF_CONNTRACK_EVENTS
@@ -337,14 +337,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  static int
  ctnetlink_expect_event(unsigned int events, const struct nf_exp_event *item)
  {
-@@ -3143,6 +3151,7 @@ errout:
+@@ -3145,6 +3146,7 @@
+ 	nfnetlink_set_err(net, 0, 0, -ENOBUFS);
  	return 0;
  }
- #endif
 +#endif
- static int ctnetlink_exp_done(struct netlink_callback *cb)
- {
- 	if (cb->args[1])
+ #endif
+ static unsigned long ctnetlink_exp_id(const struct nf_conntrack_expect *exp)
 @@ -3750,11 +3759,17 @@ static int ctnetlink_stat_exp_cpu(struct
  }
  

--- a/hack-6.6/952-add-net-conntrack-events-support-multiple-registrant.patch
+++ b/hack-6.6/952-add-net-conntrack-events-support-multiple-registrant.patch
@@ -25,7 +25,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
 @@ -65,9 +65,14 @@ struct nf_ct_event_notifier {
  	int (*exp_event)(unsigned int events, const struct nf_exp_event *item);
  };
-
+ 
 -void nf_conntrack_register_notifier(struct net *net,
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +extern int nf_conntrack_register_notifier(struct net *net, struct notifier_block *nb);
@@ -35,7 +35,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  				   const struct nf_ct_event_notifier *nb);
  void nf_conntrack_unregister_notifier(struct net *net);
 +#endif
-
+ 
  void nf_ct_deliver_cached_events(struct nf_conn *ct);
  int nf_conntrack_eventmask_report(unsigned int eventmask, struct nf_conn *ct,
 @@ -98,11 +103,13 @@ static inline void
@@ -46,11 +46,11 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	struct nf_conntrack_ecache *e;
 +#ifndef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +	struct net *net = nf_ct_net(ct);
-
+ 
  	if (!rcu_access_pointer(net->ct.nf_conntrack_event_cb))
  		return;
 +#endif
-
+ 
  	e = nf_ct_ecache_find(ct);
  	if (e == NULL)
 @@ -117,20 +124,34 @@ nf_conntrack_event_report(enum ip_conntr
@@ -71,7 +71,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	return 0;
 +#endif
  }
-
+ 
  static inline int
  nf_conntrack_event(enum ip_conntrack_events event, struct nf_conn *ct)
  {
@@ -90,13 +90,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	return 0;
 +#endif
  }
-
+ 
  #ifdef CONFIG_NF_CONNTRACK_EVENTS
 --- a/include/net/netns/conntrack.h
 +++ b/include/net/netns/conntrack.h
 @@ -105,6 +105,9 @@ struct netns_ct {
  	u8			sysctl_checksum;
-
+ 
  	struct ip_conntrack_stat __percpu *stat;
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +	struct atomic_notifier_head nf_conntrack_chain;
@@ -107,9 +107,9 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
 --- a/net/netfilter/Kconfig
 +++ b/net/netfilter/Kconfig
 @@ -161,6 +161,14 @@ config NF_CONNTRACK_EVENTS
-
+ 
  	  If unsure, say `N'.
-
+ 
 +config NF_CONNTRACK_CHAIN_EVENTS
 +	bool "Register multiple callbacks to ct events"
 +	depends on NF_CONNTRACK_EVENTS
@@ -126,13 +126,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
 @@ -2809,6 +2809,10 @@ int nf_conntrack_init_net(struct net *ne
  	nf_conntrack_ecache_pernet_init(net);
  	nf_conntrack_proto_pernet_init(net);
-
+ 
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +	ATOMIC_INIT_NOTIFIER_HEAD(&net->ct.nf_conntrack_chain);
 +#endif
 +
  	return 0;
-
+ 
  err_expect:
 --- a/net/netfilter/nf_conntrack_ecache.c
 +++ b/net/netfilter/nf_conntrack_ecache.c
@@ -156,10 +156,10 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  					   const u32 events,
  					   const u32 missed,
 @@ -161,7 +164,36 @@ static int __nf_conntrack_eventmask_repo
-
+ 
  	return ret;
  }
-+#endif
++#endif 
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +int nf_conntrack_eventmask_report(unsigned int eventmask, struct nf_conn *ct,
 +				  u32 portid, int report)
@@ -185,7 +185,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
 +
 +		atomic_notifier_call_chain(&net->ct.nf_conntrack_chain, eventmask | missed, &item);
 +	}
-
+ 
 +	return 0;
 +}
 +#else
@@ -193,12 +193,12 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  				  u32 portid, int report)
  {
 @@ -197,10 +229,52 @@ int nf_conntrack_eventmask_report(unsign
-
+ 
  	return ret;
  }
 +#endif
  EXPORT_SYMBOL_GPL(nf_conntrack_eventmask_report);
-
+ 
  /* deliver cached events and clear cache entry - must be called with locally
   * disabled softirqs */
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
@@ -251,12 +251,12 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  }
 +#endif
  EXPORT_SYMBOL_GPL(nf_ct_deliver_cached_events);
-
+ 
  void nf_ct_expect_event_report(enum ip_conntrack_expect_events event,
 @@ -258,20 +333,43 @@ out_unlock:
  	rcu_read_unlock();
  }
-
+ 
 -void nf_conntrack_register_notifier(struct net *net,
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +int nf_conntrack_register_notifier(struct net *net,
@@ -270,7 +270,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  {
 +	int ret;
  	struct nf_ct_event_notifier *notify;
-
+ 
  	mutex_lock(&nf_ct_ecache_mutex);
  	notify = rcu_dereference_protected(net->ct.nf_conntrack_event_cb,
  					   lockdep_is_held(&nf_ct_ecache_mutex));
@@ -289,7 +289,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  }
 +#endif
  EXPORT_SYMBOL_GPL(nf_conntrack_register_notifier);
-
+ 
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +int nf_conntrack_unregister_notifier(struct net *net, struct notifier_block *nb)
 +{
@@ -305,13 +305,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  }
 +#endif
  EXPORT_SYMBOL_GPL(nf_conntrack_unregister_notifier);
-
+ 
  void nf_conntrack_ecache_work(struct net *net, enum nf_ct_ecache_state state)
 --- a/net/netfilter/nf_conntrack_netlink.c
 +++ b/net/netfilter/nf_conntrack_netlink.c
 @@ -718,12 +718,19 @@ static size_t ctnetlink_nlmsg_size(const
  }
-
+ 
  static int
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +ctnetlink_conntrack_event(struct notifier_block *this, unsigned long events, void *ptr)
@@ -331,7 +331,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	unsigned int type;
 @@ -3094,6 +3101,7 @@ nla_put_failure:
  }
-
+ 
  #ifdef CONFIG_NF_CONNTRACK_EVENTS
 +#ifndef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
  static int
@@ -342,12 +342,11 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  }
  #endif
 +#endif
-
  static unsigned long ctnetlink_exp_id(const struct nf_conntrack_expect *exp)
  {
 @@ -3750,11 +3759,17 @@ static int ctnetlink_stat_exp_cpu(struct
  }
-
+ 
  #ifdef CONFIG_NF_CONNTRACK_EVENTS
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +static struct notifier_block ctnl_notifier = {
@@ -360,7 +359,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  };
  #endif
 +#endif
-
+ 
  static const struct nfnl_callback ctnl_cb[IPCTNL_MSG_MAX] = {
  	[IPCTNL_MSG_CT_NEW]	= {
 @@ -3853,8 +3868,12 @@ static int __net_init ctnetlink_net_init
@@ -374,5 +373,5 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  #endif
 +#endif
  }
-
+ 
  static struct pernet_operations ctnetlink_net_ops = {

--- a/hack-6.6/952-add-net-conntrack-events-support-multiple-registrant.patch
+++ b/hack-6.6/952-add-net-conntrack-events-support-multiple-registrant.patch
@@ -25,7 +25,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
 @@ -65,9 +65,14 @@ struct nf_ct_event_notifier {
  	int (*exp_event)(unsigned int events, const struct nf_exp_event *item);
  };
- 
+
 -void nf_conntrack_register_notifier(struct net *net,
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +extern int nf_conntrack_register_notifier(struct net *net, struct notifier_block *nb);
@@ -35,7 +35,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  				   const struct nf_ct_event_notifier *nb);
  void nf_conntrack_unregister_notifier(struct net *net);
 +#endif
- 
+
  void nf_ct_deliver_cached_events(struct nf_conn *ct);
  int nf_conntrack_eventmask_report(unsigned int eventmask, struct nf_conn *ct,
 @@ -98,11 +103,13 @@ static inline void
@@ -46,11 +46,11 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	struct nf_conntrack_ecache *e;
 +#ifndef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +	struct net *net = nf_ct_net(ct);
- 
+
  	if (!rcu_access_pointer(net->ct.nf_conntrack_event_cb))
  		return;
 +#endif
- 
+
  	e = nf_ct_ecache_find(ct);
  	if (e == NULL)
 @@ -117,20 +124,34 @@ nf_conntrack_event_report(enum ip_conntr
@@ -71,7 +71,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	return 0;
 +#endif
  }
- 
+
  static inline int
  nf_conntrack_event(enum ip_conntrack_events event, struct nf_conn *ct)
  {
@@ -90,13 +90,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	return 0;
 +#endif
  }
- 
+
  #ifdef CONFIG_NF_CONNTRACK_EVENTS
 --- a/include/net/netns/conntrack.h
 +++ b/include/net/netns/conntrack.h
 @@ -105,6 +105,9 @@ struct netns_ct {
  	u8			sysctl_checksum;
- 
+
  	struct ip_conntrack_stat __percpu *stat;
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +	struct atomic_notifier_head nf_conntrack_chain;
@@ -107,9 +107,9 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
 --- a/net/netfilter/Kconfig
 +++ b/net/netfilter/Kconfig
 @@ -161,6 +161,14 @@ config NF_CONNTRACK_EVENTS
- 
+
  	  If unsure, say `N'.
- 
+
 +config NF_CONNTRACK_CHAIN_EVENTS
 +	bool "Register multiple callbacks to ct events"
 +	depends on NF_CONNTRACK_EVENTS
@@ -126,13 +126,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
 @@ -2809,6 +2809,10 @@ int nf_conntrack_init_net(struct net *ne
  	nf_conntrack_ecache_pernet_init(net);
  	nf_conntrack_proto_pernet_init(net);
- 
+
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +	ATOMIC_INIT_NOTIFIER_HEAD(&net->ct.nf_conntrack_chain);
 +#endif
 +
  	return 0;
- 
+
  err_expect:
 --- a/net/netfilter/nf_conntrack_ecache.c
 +++ b/net/netfilter/nf_conntrack_ecache.c
@@ -156,10 +156,10 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  					   const u32 events,
  					   const u32 missed,
 @@ -161,7 +164,36 @@ static int __nf_conntrack_eventmask_repo
- 
+
  	return ret;
  }
-+#endif 
++#endif
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +int nf_conntrack_eventmask_report(unsigned int eventmask, struct nf_conn *ct,
 +				  u32 portid, int report)
@@ -185,7 +185,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
 +
 +		atomic_notifier_call_chain(&net->ct.nf_conntrack_chain, eventmask | missed, &item);
 +	}
- 
+
 +	return 0;
 +}
 +#else
@@ -193,12 +193,12 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  				  u32 portid, int report)
  {
 @@ -197,10 +229,52 @@ int nf_conntrack_eventmask_report(unsign
- 
+
  	return ret;
  }
 +#endif
  EXPORT_SYMBOL_GPL(nf_conntrack_eventmask_report);
- 
+
  /* deliver cached events and clear cache entry - must be called with locally
   * disabled softirqs */
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
@@ -251,12 +251,12 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  }
 +#endif
  EXPORT_SYMBOL_GPL(nf_ct_deliver_cached_events);
- 
+
  void nf_ct_expect_event_report(enum ip_conntrack_expect_events event,
 @@ -258,20 +333,43 @@ out_unlock:
  	rcu_read_unlock();
  }
- 
+
 -void nf_conntrack_register_notifier(struct net *net,
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +int nf_conntrack_register_notifier(struct net *net,
@@ -270,7 +270,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  {
 +	int ret;
  	struct nf_ct_event_notifier *notify;
- 
+
  	mutex_lock(&nf_ct_ecache_mutex);
  	notify = rcu_dereference_protected(net->ct.nf_conntrack_event_cb,
  					   lockdep_is_held(&nf_ct_ecache_mutex));
@@ -289,7 +289,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  }
 +#endif
  EXPORT_SYMBOL_GPL(nf_conntrack_register_notifier);
- 
+
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +int nf_conntrack_unregister_notifier(struct net *net, struct notifier_block *nb)
 +{
@@ -305,13 +305,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  }
 +#endif
  EXPORT_SYMBOL_GPL(nf_conntrack_unregister_notifier);
- 
+
  void nf_conntrack_ecache_work(struct net *net, enum nf_ct_ecache_state state)
 --- a/net/netfilter/nf_conntrack_netlink.c
 +++ b/net/netfilter/nf_conntrack_netlink.c
 @@ -718,12 +718,19 @@ static size_t ctnetlink_nlmsg_size(const
  }
- 
+
  static int
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +ctnetlink_conntrack_event(struct notifier_block *this, unsigned long events, void *ptr)
@@ -331,23 +331,23 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	unsigned int type;
 @@ -3094,6 +3101,7 @@ nla_put_failure:
  }
- 
+
  #ifdef CONFIG_NF_CONNTRACK_EVENTS
 +#ifndef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
  static int
  ctnetlink_expect_event(unsigned int events, const struct nf_exp_event *item)
  {
-@@ -3143,6 +3151,7 @@ errout:
+@@ -3144,6 +3152,7 @@ errout:
  	return 0;
  }
  #endif
 +#endif
- static int ctnetlink_exp_done(struct netlink_callback *cb)
+
+ static unsigned long ctnetlink_exp_id(const struct nf_conntrack_expect *exp)
  {
- 	if (cb->args[1])
 @@ -3750,11 +3759,17 @@ static int ctnetlink_stat_exp_cpu(struct
  }
- 
+
  #ifdef CONFIG_NF_CONNTRACK_EVENTS
 +#ifdef CONFIG_NF_CONNTRACK_CHAIN_EVENTS
 +static struct notifier_block ctnl_notifier = {
@@ -360,7 +360,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  };
  #endif
 +#endif
- 
+
  static const struct nfnl_callback ctnl_cb[IPCTNL_MSG_MAX] = {
  	[IPCTNL_MSG_CT_NEW]	= {
 @@ -3853,8 +3868,12 @@ static int __net_init ctnetlink_net_init
@@ -374,5 +374,5 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  #endif
 +#endif
  }
- 
+
  static struct pernet_operations ctnetlink_net_ops = {

--- a/hack-6.6/952-add-net-conntrack-events-support-multiple-registrant.patch
+++ b/hack-6.6/952-add-net-conntrack-events-support-multiple-registrant.patch
@@ -337,14 +337,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  static int
  ctnetlink_expect_event(unsigned int events, const struct nf_exp_event *item)
  {
-@@ -3143,6 +3151,7 @@ errout:
+@@ -3144,6 +3152,7 @@ errout:
  	return 0;
  }
  #endif
 +#endif
- static int ctnetlink_exp_done(struct netlink_callback *cb)
+ static unsigned long ctnetlink_exp_id(const struct nf_conntrack_expect *exp)
  {
- 	if (cb->args[1])
 @@ -3750,11 +3759,17 @@ static int ctnetlink_stat_exp_cpu(struct
  }
  


### PR DESCRIPTION
fix: refresh conntrack multi-registrant patch for linux 6.6 and 6.12

- Adjust the `nf_conntrack_netlink.c` hunks in
`952-add-net-conntrack-events-support-multiple-registrant.patch`
to match the Linux 6.6.113 and 6.12.79 source layout
- This fixes the stale hunk placement that caused patch apply failures
around `ctnetlink_expect_event()` and keeps the conditional closing
at the correct location for both kernel trees