### PR TITLE
fix: refresh conntrack multi-registrant patch for linux 6.6 and 6.12

### DIFF
--- a/hack-6.12/952-add-net-conntrack-events-support-multiple-registrant.patch
+++ b/hack-6.12/952-add-net-conntrack-events-support-multiple-registrant.patch
@@ -329,7 +329,7 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  	struct nf_conn *ct = item->ct;
  	struct sk_buff *skb;
  	unsigned int type;
-@@ -3094,6 +3101,7 @@ nla_put_failure:
+@@ -3097,6 +3097,7 @@
  }
  
  #ifdef CONFIG_NF_CONNTRACK_EVENTS
@@ -337,14 +337,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  static int
  ctnetlink_expect_event(unsigned int events, const struct nf_exp_event *item)
  {
-@@ -3143,6 +3151,7 @@ errout:
+@@ -3145,6 +3146,7 @@
+ 	nfnetlink_set_err(net, 0, 0, -ENOBUFS);
  	return 0;
  }
- #endif
 +#endif
- static int ctnetlink_exp_done(struct netlink_callback *cb)
- {
- 	if (cb->args[1])
+ #endif
+ static unsigned long ctnetlink_exp_id(const struct nf_conntrack_expect *exp)
 @@ -3750,11 +3759,17 @@ static int ctnetlink_stat_exp_cpu(struct
  }
  

--- a/hack-6.6/952-add-net-conntrack-events-support-multiple-registrant.patch
+++ b/hack-6.6/952-add-net-conntrack-events-support-multiple-registrant.patch
@@ -337,14 +337,13 @@ Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
  static int
  ctnetlink_expect_event(unsigned int events, const struct nf_exp_event *item)
  {
-@@ -3143,6 +3151,7 @@ errout:
+@@ -3144,6 +3152,7 @@ errout:
  	return 0;
  }
  #endif
 +#endif
- static int ctnetlink_exp_done(struct netlink_callback *cb)
+ static unsigned long ctnetlink_exp_id(const struct nf_conntrack_expect *exp)
  {
- 	if (cb->args[1])
 @@ -3750,11 +3759,17 @@ static int ctnetlink_stat_exp_cpu(struct
  }
  


### PR DESCRIPTION
- Adjust the `nf_conntrack_netlink.c` hunks in `952-add-net-conntrack-events-support-multiple-registrant.patch` to match the Linux 6.6.113 and 6.12.79 source layout
- This fixes the stale hunk placement that caused patch apply failures around `ctnetlink_expect_event()` and keeps the conditional closing at the correct location for both kernel trees